### PR TITLE
Updated the APScorer Field

### DIFF
--- a/DML/Triggers/TrigCalcAPScorer.sql
+++ b/DML/Triggers/TrigCalcAPScorer.sql
@@ -3,8 +3,8 @@ ON Results
 AFTER insert, delete, update
 AS 
     BEGIN 
-           Update Students
-		   SET APScorer = dbo.udfCalculateAPScore(StudentID)
+           Update [dbo].[Students]
+		   SET [ApScore] = dbo.udfCalculateAPScore(StudentID)
 
 		   if @@Error <> 0
            begin


### PR DESCRIPTION
For this trigger to be effective, you need to

- Drop the [dbo].[Results] Table and Recreate it.
- Execute this Trigger
- Then reinsert data on the Results Table. 

**NB:** Make sure to execute dbo.udfCalculateAPScore func prior.